### PR TITLE
Fixes shortcode closure, terms page links, base href URL, and adjusts for new delimit behavior.

### DIFF
--- a/docs/content/feature/custom-layouts.md
+++ b/docs/content/feature/custom-layouts.md
@@ -85,5 +85,5 @@ Adjust `list.html` and `single.html` layouts and use [Custom Styles](../custom-s
 - {{< external "https://devdocs.io" />}} for a comprehensive HTML and CSS reference
 - {{< external "https://internetingishard.com" />}} learn HTML & CSS for free
 - {{< external "https://inclusive-components.design" />}} for design pattern ideas
-- {{< external "https://diveintohtml5.info" >}} background behind HTML5
+- {{< external "https://diveintohtml5.info" />}} background behind HTML5
 - {{< external "https://gsnedders.html5.org/outliner/" />}} test your HTML document outline

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -33,7 +33,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
     {{ if or (in $noindex_kinds .Kind) ($is_noindex_true) }}
       <meta name="robots" content="noindex">
     {{ end }}
-    <base href="{{ .Site.BaseURL }}" />
+    <base href="{{ .Permalink }}" />
     {{ template "_internal/opengraph.html" . }}
     {{ template "_internal/twitter_cards.html" . }}
     {{ partial "meta/ogimage-maybe.html" . }}

--- a/layouts/_default/terms.html
+++ b/layouts/_default/terms.html
@@ -26,7 +26,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
   </header>
   <ul>
     {{ range $key, $value := .Data.Terms }}
-      <li><a href="{{ $key | urlize }}">{{ $key }}</a> ({{ len $value }})
+      <li><a href="{{ .Page.Permalink }}">{{ $key }}</a> ({{ len $value }})
     {{ end }}
   </ul>
 {{ end }}

--- a/layouts/partials/post/byline.html
+++ b/layouts/partials/post/byline.html
@@ -30,10 +30,10 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
     {{ dateFormat "2 Jan, 2006" (default .Date (.PublishDate)) }}
   </time>
   {{ with .Params.categories }}
-    in <span itemprop="articleSection">{{ delimit (apply (apply (sort .) "partial" "post/category-link.html" ".") "chomp" ".") ", " " and " }}</span>
+    in <span itemprop="articleSection">{{ delimit (apply (apply (sort .) "partial" "post/category-link.html" ".") "chomp" ".") ", " " and " | safeHTML }}</span>
   {{ end }}
   {{ with .Params.tags }}
-    and tagged {{ delimit (apply (apply (sort .) "partial" "post/tag-link.html" ".") "chomp" ".") ", " " and " }}
+    and tagged {{ delimit (apply (apply (sort .) "partial" "post/tag-link.html" ".") "chomp" ".") ", " " and " | safeHTML }}
   {{ end }}
   using <span itemprop="wordCount">{{ .WordCount }}</span> words.
 </p>


### PR DESCRIPTION
Minor fixes to the theme:

- Fix external shortcode closure in custom layouts doc.
- Fix terms pages links that were not being calculated relative to the page itself.
- Fix base href URL so it's relative to the actual development host, not the configured production URL.
- Fix byline URLs to accommodate new delimit behavior by piping through safeHTML.

